### PR TITLE
updated tag fixtures

### DIFF
--- a/rareapi/fixtures/tags.json
+++ b/rareapi/fixtures/tags.json
@@ -3,21 +3,21 @@
     "model": "rareapi.tag",
     "pk": 1,
     "fields": {
-      "label": "#Bonnaroo"
+      "label": "Bonnaroo"
     }
   },
     {
     "model": "rareapi.tag",
     "pk": 2,
     "fields": {
-      "label": "#Dogs"
+      "label": "Dogs"
     }
   },
     {
     "model": "rareapi.tag",
     "pk": 3,
     "fields": {
-      "label": "#Music"
+      "label": "Music"
     }
   }
 ]


### PR DESCRIPTION
This pull request updates the `rareapi/fixtures/tags.json` file to remove hashtags from the `label` field values for consistency and improved readability.

* Changes to `rareapi/fixtures/tags.json`:
  * Removed the `#` prefix from the `label` fields of tags with primary keys 1, 2, and 3, changing them from `#Bonnaroo`, `#Dogs`, and `#Music` to `Bonnaroo`, `Dogs`, and `Music` respectively.