### PR TITLE
added depth to posttag for access to tag label on FE, fixed double create issue in post view (use .save() only, rm .create()

### DIFF
--- a/rareapi/serializers/postTag.py
+++ b/rareapi/serializers/postTag.py
@@ -1,7 +1,9 @@
 from rest_framework import serializers
 from ..models.postTag import PostTag
 
+
 class PostTagSerializer(serializers.ModelSerializer):
     class Meta:
         model = PostTag
         fields = '__all__'
+        depth = 1

--- a/rareapi/views/post.py
+++ b/rareapi/views/post.py
@@ -28,16 +28,7 @@ class PostView(ViewSet):
     # POST /posts/
 
     def create(self, request):
-        userId = User.objects.get(pk=request.data["user_id"])
-        category = Category.objects.get(pk=request.data["category_id"])
-        post = Post.objects.create(
-        user=userId,
-        category=category,
-        title=request.data["title"],
-        publication_date=request.data["publication_date"],
-        image_url=request.data["image_url"],
-        content=request.data["content"],
-    )
+
         serializer = PostSerializer(data=request.data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
This pull request introduces improvements to the `rareapi` application by enhancing the `PostTagSerializer` and refactoring the `create` method in the `Post` view. The changes aim to simplify the codebase and improve serialization behavior.

### Serialization Enhancements:
* [`rareapi/serializers/postTag.py`](diffhunk://#diff-867fdeb07e927c2b5de854bb713ea04f32011e1b3ce3063410f9b1c05d231371R4-R9): Added a `depth` attribute with a value of `1` to the `PostTagSerializer` to enable nested serialization for related objects.

### Code Simplification:
* [`rareapi/views/post.py`](diffhunk://#diff-0d3f2cdc3ed59f787545c7f697b0bfd4837d25bb310ea5221eeda898d17e758bL31-R31): Refactored the `create` method in the `Post` view to use the `PostSerializer` directly for object creation, replacing manual instantiation of related objects (`User` and `Category`) and the `Post` model. This reduces redundancy and leverages serializer validation.